### PR TITLE
fix(sql): use camel case for column names

### DIFF
--- a/server/services/users.js
+++ b/server/services/users.js
@@ -2,6 +2,8 @@
 
 const encryption = require('./encryption');
 
+const columns = 'id, first_name as "firstName", last_name as "lastName", email';
+
 module.exports = class Users {
   constructor(pool) {
     this._pool = pool;
@@ -9,7 +11,7 @@ module.exports = class Users {
 
   async getAll() {
     const client = await this._pool.connect();
-    const data = await client.query('select * from users');
+    const data = await client.query(`select ${columns} from users`);
     client.release();
     return data.rows;
   }
@@ -17,8 +19,8 @@ module.exports = class Users {
   async get(id) {
     const client = await this._pool.connect();
     const data = await (/.*@.*/.test(id)
-      ? client.query('select * from users where upper(email) = upper($1)', [id])
-      : client.query('select * from users where id = $1', [id]));
+      ? client.query(`select ${columns} from users where upper(email) = upper($1)`, [id])
+      : client.query(`select ${columns} from users where id = $1`, [id]));
     client.release();
     const user = data.rows && data.rows[0];
     if (user) {
@@ -33,12 +35,12 @@ module.exports = class Users {
     if (user.id) {
       rtn = await client.query(
         'update users set first_name = $2, last_name = $3, email = $4 where id = $1 returning *',
-        [user.id, user.first_name, user.last_name, user.email]
+        [user.id, user.firstName, user.lastName, user.email]
       );
     } else {
       rtn = await client.query(
         'insert into users(first_name, last_name, email) values($1, $2, $3) returning *',
-        [user.first_name, user.last_name, user.email]
+        [user.firstName, user.lastName, user.email]
       );
     }
     client.release();

--- a/test/server/config/passport.spec.js
+++ b/test/server/config/passport.spec.js
@@ -78,8 +78,8 @@ describe('config: passport', function() {
       beforeEach(function() {
         user = {
           id: 1138,
-          first_name: 'Karl',
-          last_name: 'Smith'
+          firstName: 'Karl',
+          lastName: 'Smith'
         };
         users.get.returns(Promise.resolve(user));
       });

--- a/test/server/routes/users.spec.js
+++ b/test/server/routes/users.spec.js
@@ -44,8 +44,8 @@ describe('route: /api/users', function() {
     sinon.stub(mockJWT, 'verify');
     mockJWT.verify.returns({
       id: 1138,
-      first_name: 'Ted',
-      last_name: 'Senspeck',
+      firstName: 'Ted',
+      lastName: 'Senspeck',
       roles: ['admin'],
       iat: 'whatever',
       exp: 19930124509912485
@@ -58,23 +58,23 @@ describe('route: /api/users', function() {
     testData = [
       {
         id: 10,
-        first_name: 'Fred',
-        last_name: 'Flintstone'
+        firstName: 'Fred',
+        lastName: 'Flintstone'
       },
       {
         id: 20,
-        first_name: 'Wilma',
-        last_name: 'Flintstone'
+        firstName: 'Wilma',
+        lastName: 'Flintstone'
       },
       {
         id: 30,
-        first_name: 'Barney',
-        last_name: 'Rubble'
+        firstName: 'Barney',
+        lastName: 'Rubble'
       },
       {
         id: 40,
-        first_name: 'Betty',
-        last_name: 'Rubble'
+        firstName: 'Betty',
+        lastName: 'Rubble'
       }
     ];
     proxyquire('../../../server/routes/users', {
@@ -123,8 +123,8 @@ describe('route: /api/users', function() {
             expect(res.status).to.equal(200);
             expect(res.body).to.deep.equal({
               id: 30,
-              first_name: 'Barney',
-              last_name: 'Rubble'
+              firstName: 'Barney',
+              lastName: 'Rubble'
             });
             done();
           });
@@ -133,8 +133,8 @@ describe('route: /api/users', function() {
       it('returns the data if the ids match', function(done) {
         mockJWT.verify.returns({
           id: 30,
-          first_name: 'Barney',
-          last_name: 'Rubble',
+          firstName: 'Barney',
+          lastName: 'Rubble',
           roles: ['user'],
           iat: 'whatever',
           exp: 19930124509912485
@@ -145,8 +145,8 @@ describe('route: /api/users', function() {
             expect(res.status).to.equal(200);
             expect(res.body).to.deep.equal({
               id: 30,
-              first_name: 'Barney',
-              last_name: 'Rubble'
+              firstName: 'Barney',
+              lastName: 'Rubble'
             });
             done();
           });
@@ -155,8 +155,8 @@ describe('route: /api/users', function() {
       it('returns 403 if user not admin and ids do not match', function(done) {
         mockJWT.verify.returns({
           id: 10,
-          first_name: 'Fred',
-          last_name: 'Flintstone',
+          firstName: 'Fred',
+          lastName: 'Flintstone',
           roles: ['user'],
           iat: 'whatever',
           exp: 19930124509912485
@@ -194,8 +194,8 @@ describe('route: /api/users', function() {
           .post('/api/users/30')
           .send({
             id: 30,
-            first_name: 'Barney',
-            last_name: 'Rubble',
+            firstName: 'Barney',
+            lastName: 'Rubble',
             email: 'barney@rubble.kings.io'
           })
           .end(function(err, res) {
@@ -210,16 +210,16 @@ describe('route: /api/users', function() {
           .post('/api/users/30')
           .send({
             id: 30,
-            first_name: 'Barney',
-            last_name: 'Rubble',
+            firstName: 'Barney',
+            lastName: 'Rubble',
             email: 'barney@rubble.kings.io'
           })
           .end(function(err, res) {
             expect(saveCalled).to.equal(1);
             expect(saveCalledWith).to.deep.equal({
               id: 30,
-              first_name: 'Barney',
-              last_name: 'Rubble',
+              firstName: 'Barney',
+              lastName: 'Rubble',
               email: 'barney@rubble.kings.io'
             });
             done();
@@ -229,8 +229,8 @@ describe('route: /api/users', function() {
       it('calls the save if own user', done => {
         mockJWT.verify.returns({
           id: 30,
-          first_name: 'Barney',
-          last_name: 'Rubble',
+          firstName: 'Barney',
+          lastName: 'Rubble',
           roles: ['user'],
           iat: 'whatever',
           exp: 19930124509912485
@@ -239,16 +239,16 @@ describe('route: /api/users', function() {
           .post('/api/users/30')
           .send({
             id: 30,
-            first_name: 'Barney',
-            last_name: 'Rubble',
+            firstName: 'Barney',
+            lastName: 'Rubble',
             email: 'barney@rubble.kings.io'
           })
           .end(function(err, res) {
             expect(saveCalled).to.equal(1);
             expect(saveCalledWith).to.deep.equal({
               id: 30,
-              first_name: 'Barney',
-              last_name: 'Rubble',
+              firstName: 'Barney',
+              lastName: 'Rubble',
               email: 'barney@rubble.kings.io'
             });
             done();
@@ -260,16 +260,16 @@ describe('route: /api/users', function() {
           .post('/api/users/30')
           .send({
             id: 30,
-            first_name: 'Barney',
-            last_name: 'Rubble',
+            firstName: 'Barney',
+            lastName: 'Rubble',
             email: 'barney@rubble.kings.io'
           })
           .end(function(err, res) {
             expect(res.status).to.equal(200);
             expect(res.body).to.deep.equal({
               id: 30,
-              first_name: 'Barney',
-              last_name: 'Rubble',
+              firstName: 'Barney',
+              lastName: 'Rubble',
               email: 'barney@rubble.kings.io'
             });
             done();
@@ -281,16 +281,16 @@ describe('route: /api/users', function() {
           .post('/api/users/30')
           .send({
             id: 42,
-            first_name: 'Barney',
-            last_name: 'Rubble',
+            firstName: 'Barney',
+            lastName: 'Rubble',
             email: 'barney@rubble.kings.io'
           })
           .end(function(err, res) {
             expect(saveCalled).to.equal(1);
             expect(saveCalledWith).to.deep.equal({
               id: 30,
-              first_name: 'Barney',
-              last_name: 'Rubble',
+              firstName: 'Barney',
+              lastName: 'Rubble',
               email: 'barney@rubble.kings.io'
             });
             done();
@@ -302,8 +302,8 @@ describe('route: /api/users', function() {
           .post('/api/users/42')
           .send({
             id: 42,
-            first_name: 'Barney',
-            last_name: 'Rubble',
+            firstName: 'Barney',
+            lastName: 'Rubble',
             email: 'barney@rubble.kings.io'
           })
           .end(function(err, res) {
@@ -316,8 +316,8 @@ describe('route: /api/users', function() {
       it('returns 403 if not admin and not own user', done => {
         mockJWT.verify.returns({
           id: 10,
-          first_name: 'Fred',
-          last_name: 'Flintstone',
+          firstName: 'Fred',
+          lastName: 'Flintstone',
           roles: ['user'],
           iat: 'whatever',
           exp: 19930124509912485
@@ -326,8 +326,8 @@ describe('route: /api/users', function() {
           .post('/api/users/42')
           .send({
             id: 42,
-            first_name: 'Barney',
-            last_name: 'Rubble',
+            firstName: 'Barney',
+            lastName: 'Rubble',
             email: 'barney@rubble.kings.io'
           })
           .end(function(err, res) {
@@ -344,8 +344,8 @@ describe('route: /api/users', function() {
         request(app)
           .post('/api/users')
           .send({
-            first_name: 'Barney',
-            last_name: 'Rubble',
+            firstName: 'Barney',
+            lastName: 'Rubble',
             email: 'barney@rubble.kings.io'
           })
           .end(function(err, res) {
@@ -359,15 +359,15 @@ describe('route: /api/users', function() {
         request(app)
           .post('/api/users')
           .send({
-            first_name: 'Barney',
-            last_name: 'Rubble',
+            firstName: 'Barney',
+            lastName: 'Rubble',
             email: 'barney@rubble.kings.io'
           })
           .end(function(err, res) {
             expect(saveCalled).to.equal(1);
             expect(saveCalledWith).to.deep.equal({
-              first_name: 'Barney',
-              last_name: 'Rubble',
+              firstName: 'Barney',
+              lastName: 'Rubble',
               email: 'barney@rubble.kings.io'
             });
             done();
@@ -378,16 +378,16 @@ describe('route: /api/users', function() {
         request(app)
           .post('/api/users')
           .send({
-            first_name: 'Barney',
-            last_name: 'Rubble',
+            firstName: 'Barney',
+            lastName: 'Rubble',
             email: 'barney@rubble.kings.io'
           })
           .end(function(err, res) {
             expect(res.status).to.equal(200);
             expect(res.body).to.deep.equal({
               id: 314159,
-              first_name: 'Barney',
-              last_name: 'Rubble',
+              firstName: 'Barney',
+              lastName: 'Rubble',
               email: 'barney@rubble.kings.io'
             });
             done();
@@ -399,15 +399,15 @@ describe('route: /api/users', function() {
           .post('/api/users')
           .send({
             id: 42,
-            first_name: 'Barney',
-            last_name: 'Rubble',
+            firstName: 'Barney',
+            lastName: 'Rubble',
             email: 'barney@rubble.kings.io'
           })
           .end(function(err, res) {
             expect(saveCalled).to.equal(1);
             expect(saveCalledWith).to.deep.equal({
-              first_name: 'Barney',
-              last_name: 'Rubble',
+              firstName: 'Barney',
+              lastName: 'Rubble',
               email: 'barney@rubble.kings.io'
             });
             done();
@@ -417,8 +417,8 @@ describe('route: /api/users', function() {
       it('returns 403 if not admin', done => {
         mockJWT.verify.returns({
           id: 10,
-          first_name: 'Fred',
-          last_name: 'Flintstone',
+          firstName: 'Fred',
+          lastName: 'Flintstone',
           roles: ['user'],
           iat: 'whatever',
           exp: 19930124509912485
@@ -426,8 +426,8 @@ describe('route: /api/users', function() {
         request(app)
           .post('/api/users')
           .send({
-            first_name: 'Barney',
-            last_name: 'Rubble',
+            firstName: 'Barney',
+            lastName: 'Rubble',
             email: 'barney@rubble.kings.io'
           })
           .end(function(err, res) {

--- a/test/server/services/authentication.spec.js
+++ b/test/server/services/authentication.spec.js
@@ -96,14 +96,14 @@ describe('service: authentication', function() {
         service.authenticate(mockRequest, mockResponse, p => {});
         mockPassport.callback(null, {
           id: 42,
-          first_name: 'Jimmy',
-          last_name: 'John'
+          firstName: 'Jimmy',
+          lastName: 'John'
         });
         expect(mockRequest.logIn.calledOnce).to.be.true;
         expect(mockRequest.user).to.deep.equal({
           id: 42,
-          first_name: 'Jimmy',
-          last_name: 'John'
+          firstName: 'Jimmy',
+          lastName: 'John'
         });
         expect(mockRequest.callback).to.exist;
       });
@@ -116,8 +116,8 @@ describe('service: authentication', function() {
           });
           mockPassport.callback(null, {
             id: 42,
-            first_name: 'Jimmy',
-            last_name: 'John'
+            firstName: 'Jimmy',
+            lastName: 'John'
           });
           mockRequest.callback('I am a login error');
           expect(param).to.equal('I am a login error');
@@ -132,8 +132,8 @@ describe('service: authentication', function() {
           });
           mockPassport.callback(null, {
             id: 42,
-            first_name: 'Jimmy',
-            last_name: 'John'
+            firstName: 'Jimmy',
+            lastName: 'John'
           });
           mockRequest.callback();
           expect(param).to.be.undefined;
@@ -142,8 +142,8 @@ describe('service: authentication', function() {
             mockJWT.sign.calledWith(
               {
                 id: 42,
-                first_name: 'Jimmy',
-                last_name: 'John'
+                firstName: 'Jimmy',
+                lastName: 'John'
               },
               process.env.JWT_PRIVATE_KEY,
               { expiresIn: '10d' }
@@ -162,8 +162,8 @@ describe('service: authentication', function() {
           });
           mockPassport.callback(null, {
             id: 42,
-            first_name: 'Jimmy',
-            last_name: 'John'
+            firstName: 'Jimmy',
+            lastName: 'John'
           });
           mockRequest.callback();
           expect(param).to.be.undefined;
@@ -171,7 +171,7 @@ describe('service: authentication', function() {
           expect(
             mockResponse.send.calledWith({
               success: true,
-              user: { id: 42, first_name: 'Jimmy', last_name: 'John' },
+              user: { id: 42, firstName: 'Jimmy', lastName: 'John' },
               token: 'IAmAFakeToken'
             })
           ).to.be.true;
@@ -218,8 +218,8 @@ describe('service: authentication', function() {
     it('generates a new toekn if the verify succeeds', function() {
       mockJWT.verify.returns({
         id: 1138,
-        first_name: 'Ted',
-        last_name: 'Senspeck'
+        firstName: 'Ted',
+        lastName: 'Senspeck'
       });
       service.refresh(mockRequest, mockResponse);
       expect(mockJWT.sign.calledOnce).to.be.true;
@@ -227,8 +227,8 @@ describe('service: authentication', function() {
         mockJWT.sign.calledWith(
           {
             id: 1138,
-            first_name: 'Ted',
-            last_name: 'Senspeck'
+            firstName: 'Ted',
+            lastName: 'Senspeck'
           },
           'IAmAFakeCertificateForRefresh'
         )
@@ -238,8 +238,8 @@ describe('service: authentication', function() {
     it('strips the iat and exp props from the user', function() {
       mockJWT.verify.returns({
         id: 1138,
-        first_name: 'Ted',
-        last_name: 'Senspeck',
+        firstName: 'Ted',
+        lastName: 'Senspeck',
         iat: 'whatever',
         exp: 19930124509912485
       });
@@ -249,8 +249,8 @@ describe('service: authentication', function() {
         mockJWT.sign.calledWith(
           {
             id: 1138,
-            first_name: 'Ted',
-            last_name: 'Senspeck'
+            firstName: 'Ted',
+            lastName: 'Senspeck'
           },
           'IAmAFakeCertificateForRefresh'
         )
@@ -260,8 +260,8 @@ describe('service: authentication', function() {
     it('sends back the new token', function() {
       mockJWT.verify.returns({
         id: 1138,
-        first_name: 'Ted',
-        last_name: 'Senspeck',
+        firstName: 'Ted',
+        lastName: 'Senspeck',
         iat: 'whatever',
         exp: 19930124509912485
       });
@@ -273,8 +273,8 @@ describe('service: authentication', function() {
           success: true,
           user: {
             id: 1138,
-            first_name: 'Ted',
-            last_name: 'Senspeck'
+            firstName: 'Ted',
+            lastName: 'Senspeck'
           },
           token: 'IAmANewlyRefreshedFakeToken'
         })
@@ -317,8 +317,8 @@ describe('service: authentication', function() {
     it('returns true if the current token is not valid', function() {
       mockJWT.verify.returns({
         id: 1138,
-        first_name: 'Ted',
-        last_name: 'Senspeck',
+        firstName: 'Ted',
+        lastName: 'Senspeck',
         roles: ['admin', 'user'],
         iat: 'whatever',
         exp: 19930124509912485
@@ -350,8 +350,8 @@ describe('service: authentication', function() {
     it('goes on to next if the user is logged in', function() {
       mockJWT.verify.returns({
         id: 1138,
-        first_name: 'Ted',
-        last_name: 'Senspeck',
+        firstName: 'Ted',
+        lastName: 'Senspeck',
         roles: ['admin', 'user'],
         iat: 'whatever',
         exp: 19930124509912485
@@ -389,8 +389,8 @@ describe('service: authentication', function() {
       sinon.stub(mockJWT, 'verify');
       mockJWT.verify.returns({
         id: 1138,
-        first_name: 'Ted',
-        last_name: 'Senspeck',
+        firstName: 'Ted',
+        lastName: 'Senspeck',
         roles: ['admin', 'user'],
         iat: 'whatever',
         exp: 19930124509912485
@@ -434,8 +434,8 @@ describe('service: authentication', function() {
       sinon.stub(mockJWT, 'verify');
       mockJWT.verify.returns({
         id: 1138,
-        first_name: 'Ted',
-        last_name: 'Senspeck',
+        firstName: 'Ted',
+        lastName: 'Senspeck',
         roles: ['admin', 'user'],
         iat: 'whatever',
         exp: 19930124509912485

--- a/test/server/services/users.spec.js
+++ b/test/server/services/users.spec.js
@@ -15,14 +15,14 @@ describe('service: users', () => {
     testData = [
       {
         id: 1,
-        first_name: 'Kenneth',
-        last_name: 'Sodemann',
+        firstName: 'Kenneth',
+        lastName: 'Sodemann',
         email: 'not.my.real.email@gmail.com'
       },
       {
         id: 2,
-        first_name: 'Lisa',
-        last_name: 'Buerger',
+        firstName: 'Lisa',
+        lastName: 'Buerger',
         email: 'another.fake.email@aol.com'
       }
     ];
@@ -45,8 +45,8 @@ describe('service: users', () => {
       sinon.spy(pool.test_client, 'query');
       await service.getAll();
       expect(pool.test_client.query.calledOnce).to.be.true;
-      expect(pool.test_client.query.calledWith('select * from users')).to.be
-        .true;
+      const sql = pool.test_client.query.args[0][0];
+      expect(/select .* from users/.test(sql)).to.be.true;
     });
 
     it('resolves the data', async () => {
@@ -80,34 +80,27 @@ describe('service: users', () => {
       sinon.spy(pool.test_client, 'query');
       await service.get(42);
       expect(pool.test_client.query.calledOnce).to.be.true;
-      expect(
-        pool.test_client.query.calledWith('select * from users where id = $1', [
-          42
-        ])
-      ).to.be.true;
+      const args = pool.test_client.query.args[0];
+      expect(/select .* from users where id = \$1/.test(args[0])).to.be.true;
+      expect(args[1]).to.deep.equal([42]);
     });
 
     it('queries the users for the user with the given ID string', async () => {
       sinon.spy(pool.test_client, 'query');
       await service.get('42');
       expect(pool.test_client.query.calledOnce).to.be.true;
-      expect(
-        pool.test_client.query.calledWith('select * from users where id = $1', [
-          '42'
-        ])
-      ).to.be.true;
+      const args = pool.test_client.query.args[0];
+      expect(/select .* from users where id = \$1/.test(args[0])).to.be.true;
+      expect(args[1]).to.deep.equal(['42']);
     });
 
     it('queries the users by email if the passed id has an "@" sign', async () => {
       sinon.spy(pool.test_client, 'query');
       await service.get('42@1138.73');
       expect(pool.test_client.query.calledOnce).to.be.true;
-      expect(
-        pool.test_client.query.calledWith(
-          'select * from users where upper(email) = upper($1)',
-          ['42@1138.73']
-        )
-      ).to.be.true;
+      const args = pool.test_client.query.args[0];
+      expect(/select .* from users where upper\(email\) = upper\(\$1\)/.test(args[0])).to.be.true;
+      expect(args[1]).to.deep.equal(['42@1138.73']);
     });
 
     it('resolves the data', async () => {
@@ -117,8 +110,8 @@ describe('service: users', () => {
           rows: [
             {
               id: 42,
-              first_name: 'Ford',
-              last_name: 'Prefect',
+              firstName: 'Ford',
+              lastName: 'Prefect',
               email: 'universe.traveler@compuserve.net'
             }
           ]
@@ -127,8 +120,8 @@ describe('service: users', () => {
       const data = await service.get(42);
       expect(data).to.deep.equal({
         id: 42,
-        first_name: 'Ford',
-        last_name: 'Prefect',
+        firstName: 'Ford',
+        lastName: 'Prefect',
         email: 'universe.traveler@compuserve.net',
         roles: ['admin', 'user']
       });
@@ -158,8 +151,8 @@ describe('service: users', () => {
     it('connects to the pool', async () => {
       sinon.spy(pool, 'connect');
       await service.save({
-        first_name: 'Tess',
-        last_name: 'McTesterson'
+        firstName: 'Tess',
+        lastName: 'McTesterson'
       });
       expect(pool.connect.calledOnce).to.be.true;
     });
@@ -169,8 +162,8 @@ describe('service: users', () => {
         sinon.spy(pool.test_client, 'query');
         await service.save({
           id: 4273,
-          first_name: 'Tess',
-          last_name: 'McTesterson',
+          firstName: 'Tess',
+          lastName: 'McTesterson',
           email: 'tess@test.ly'
         });
         expect(pool.test_client.query.calledOnce).to.be.true;
@@ -186,8 +179,8 @@ describe('service: users', () => {
             rows: [
               {
                 id: 4273,
-                first_name: 'Tess',
-                last_name: 'McTesterson',
+                firstName: 'Tess',
+                lastName: 'McTesterson',
                 email: 'tess@test.ly'
               }
             ]
@@ -195,14 +188,14 @@ describe('service: users', () => {
         );
         const user = await service.save({
           id: 4273,
-          first_name: 'Tess',
-          last_name: 'McTesterson',
+          firstName: 'Tess',
+          lastName: 'McTesterson',
           email: 'tess@test.ly'
         });
         expect(user).to.deep.equal({
           id: 4273,
-          first_name: 'Tess',
-          last_name: 'McTesterson',
+          firstName: 'Tess',
+          lastName: 'McTesterson',
           email: 'tess@test.ly'
         });
       });
@@ -212,8 +205,8 @@ describe('service: users', () => {
         pool.test_client.query.returns(Promise.resolve({ rows: [] }));
         const user = await service.save({
           id: 4273,
-          first_name: 'Tess',
-          last_name: 'McTesterson',
+          firstName: 'Tess',
+          lastName: 'McTesterson',
           email: 'tess@test.ly'
         });
         expect(user).to.be.undefined;
@@ -224,8 +217,8 @@ describe('service: users', () => {
       it('creates a new user', async () => {
         sinon.spy(pool.test_client, 'query');
         await service.save({
-          first_name: 'Tess',
-          last_name: 'McTesterson',
+          firstName: 'Tess',
+          lastName: 'McTesterson',
           email: 'tess@test.ly'
         });
         expect(pool.test_client.query.calledOnce).to.be.true;
@@ -240,22 +233,22 @@ describe('service: users', () => {
             rows: [
               {
                 id: 4273,
-                first_name: 'Tess',
-                last_name: 'McTesterson',
+                firstName: 'Tess',
+                lastName: 'McTesterson',
                 email: 'tess@test.ly'
               }
             ]
           })
         );
         const user = await service.save({
-          first_name: 'Tess',
-          last_name: 'McTesterson',
+          firstName: 'Tess',
+          lastName: 'McTesterson',
           email: 'tess@test.ly'
         });
         expect(user).to.deep.equal({
           id: 4273,
-          first_name: 'Tess',
-          last_name: 'McTesterson',
+          firstName: 'Tess',
+          lastName: 'McTesterson',
           email: 'tess@test.ly'
         });
       });
@@ -264,8 +257,8 @@ describe('service: users', () => {
     it('releases the client', async () => {
       sinon.spy(pool.test_client, 'release');
       await service.save({
-        first_name: 'Tess',
-        last_name: 'McTesterson'
+        firstName: 'Tess',
+        lastName: 'McTesterson'
       });
       expect(pool.test_client.release.calledOnce).to.be.true;
     });


### PR DESCRIPTION
This only applies to the columns that are exposed to the end user, not to the column names in the database itself