### PR TITLE
refactor(test-data): limit mock HTTP functionallity

### DIFF
--- a/test/web/unit/mock-http/index.js
+++ b/test/web/unit/mock-http/index.js
@@ -2,15 +2,10 @@
 
 import Vue from 'vue';
 
-class TestData {
+class MockHttp {
   initialize() {
     sinon.stub(Vue.http, 'get');
     sinon.stub(Vue.http, 'post');
-
-    this.setResponse('/api/tea-categories', {
-      status: 200,
-      body: this.teaCategories
-    });
   }
 
   restore() {
@@ -35,29 +30,6 @@ class TestData {
       Vue.http.post.withArgs(endpoint).returns(Promise.resolve(response));
     }
   }
-
-  teaCategories = [
-    {
-      id: 1,
-      name: 'Green',
-      description: 'Non - oxidized, mild tea'
-    },
-    {
-      id: 2,
-      name: 'Black',
-      description: 'Oxidized tea'
-    },
-    {
-      id: 3,
-      name: 'Herbal',
-      description: 'Not a tea'
-    },
-    {
-      id: 4,
-      name: 'Oolong',
-      description: 'Chinese deliciousness'
-    }
-  ];
 }
 
-export default new TestData();
+export default new MockHttp();

--- a/test/web/unit/specs/api/authentication.spec.js
+++ b/test/web/unit/specs/api/authentication.spec.js
@@ -2,7 +2,7 @@
 
 import Vue from 'vue';
 import authentication from '@/api/authentication';
-import testData from '../../test-data';
+import mockHttp from '../../mock-http';
 
 const loginResponse = {
   success: true,
@@ -23,15 +23,15 @@ describe('authentication', () => {
 
   describe('login', () => {
     beforeEach(() => {
-      testData.initialize();
-      testData.setPostResponse('/api/login', {
+      mockHttp.initialize();
+      mockHttp.setPostResponse('/api/login', {
         status: 200,
         body: loginResponse
       });
     });
 
     afterEach(() => {
-      testData.restore();
+      mockHttp.restore();
     });
 
     it('posts to the login endpoint', async () => {
@@ -57,14 +57,14 @@ describe('authentication', () => {
 
   describe('logout', () => {
     beforeEach(() => {
-      testData.initialize();
-      testData.setPostResponse('/api/logout', {
+      mockHttp.initialize();
+      mockHttp.setPostResponse('/api/logout', {
         status: 200
       });
     });
 
     afterEach(() => {
-      testData.restore();
+      mockHttp.restore();
     });
 
     it('posts to the logout endpoint', async () => {

--- a/test/web/unit/specs/api/tea-categories.spec.js
+++ b/test/web/unit/specs/api/tea-categories.spec.js
@@ -2,15 +2,42 @@
 
 import Vue from 'vue';
 import teaCategories from '@/api/tea-categories';
-import testData from '../../test-data';
+import mockHttp from '../../mock-http';
 
 describe('tea-categories', () => {
+  let testData;
   beforeEach(() => {
-    testData.initialize();
+    mockHttp.initialize();
+    testData = [
+      {
+        id: 1,
+        name: 'Green',
+        description: 'Non - oxidized, mild tea'
+      },
+      {
+        id: 2,
+        name: 'Black',
+        description: 'Oxidized tea'
+      },
+      {
+        id: 3,
+        name: 'Herbal',
+        description: 'Not a tea'
+      },
+      {
+        id: 4,
+        name: 'Oolong',
+        description: 'Chinese deliciousness'
+      }
+    ];
+    mockHttp.setResponse('/api/tea-categories', {
+      status: 200,
+      body: testData
+    });
   });
 
   afterEach(() => {
-    testData.restore();
+    mockHttp.restore();
   });
 
   it('exists', () => {
@@ -26,7 +53,7 @@ describe('tea-categories', () => {
 
     it('unpacks the reponse body', async () => {
       const res = await teaCategories.getAll();
-      expect(res).to.deep.equal(testData.teaCategories);
+      expect(res).to.deep.equal(testData);
     });
   });
 });

--- a/test/web/unit/specs/api/users.spec.js
+++ b/test/web/unit/specs/api/users.spec.js
@@ -2,15 +2,15 @@
 
 import Vue from 'vue';
 import users from '@/api/users';
-import testData from '../../test-data';
+import mockHttp from '../../mock-http';
 
 describe('users', () => {
   beforeEach(() => {
-    testData.initialize();
+    mockHttp.initialize();
   });
 
   afterEach(() => {
-    testData.restore();
+    mockHttp.restore();
   });
 
   it('exists', () => {
@@ -27,7 +27,7 @@ describe('users', () => {
     };
 
     beforeEach(() => {
-      testData.setResponse('/api/users/current', {
+      mockHttp.setResponse('/api/users/current', {
         status: 200,
         body: currentUser
       });
@@ -47,7 +47,7 @@ describe('users', () => {
 
   describe('change password', () => {
     it('posts to the change password', async () => {
-      testData.setPostResponse('/api/users/42/password', {
+      mockHttp.setPostResponse('/api/users/42/password', {
         status: 200,
         body: { status: 200 }
       });
@@ -64,7 +64,7 @@ describe('users', () => {
 
   describe('save', () => {
     it('posts new users', async () => {
-      testData.setPostResponse('/api/users', {
+      mockHttp.setPostResponse('/api/users', {
         status: 200,
         body: {
           id: 73,
@@ -88,7 +88,7 @@ describe('users', () => {
     });
 
     it('posts changes to existing users', async () => {
-      testData.setPostResponse('/api/users/73', {
+      mockHttp.setPostResponse('/api/users/73', {
         status: 200,
         body: {
           id: 73,

--- a/test/web/unit/specs/components/pages/browse-by-category.spec.js
+++ b/test/web/unit/specs/components/pages/browse-by-category.spec.js
@@ -3,18 +3,45 @@
 import Vue from 'vue';
 
 import Page from '@/components/pages/browse-by-category';
-import testData from '../../../test-data';
+import mockHttp from '../../../mock-http';
 
 describe('browse-by-category.vue', () => {
+  let teaCategories;
   let vm;
   beforeEach(() => {
-    testData.initialize();
+    mockHttp.initialize();
+    teaCategories = [
+      {
+        id: 1,
+        name: 'Green',
+        description: 'Non - oxidized, mild tea'
+      },
+      {
+        id: 2,
+        name: 'Black',
+        description: 'Oxidized tea'
+      },
+      {
+        id: 3,
+        name: 'Herbal',
+        description: 'Not a tea'
+      },
+      {
+        id: 4,
+        name: 'Oolong',
+        description: 'Chinese deliciousness'
+      }
+    ];
+    mockHttp.setResponse('/api/tea-categories', {
+      status: 200,
+      body: teaCategories
+    });
     const Constructor = Vue.extend(Page);
     vm = new Constructor().$mount();
   });
 
   afterEach(() => {
-    testData.restore();
+    mockHttp.restore();
   });
 
   it('renders the correct title', () => {
@@ -25,7 +52,7 @@ describe('browse-by-category.vue', () => {
 
   it('should fetch the tea categories', () => {
     return Vue.nextTick().then(() => {
-      expect(vm.categories).to.deep.equal(testData.teaCategories);
+      expect(vm.categories).to.deep.equal(teaCategories);
     });
   });
 

--- a/test/web/unit/specs/components/pages/change-password.spec.js
+++ b/test/web/unit/specs/components/pages/change-password.spec.js
@@ -4,16 +4,16 @@ import Vue from 'vue';
 import Page from '@/components/pages/change-password';
 import store from '@/store';
 
-import testData from '../../../test-data';
+import mockHttp from '../../../mock-http';
 import util from '../../../util';
 
 describe('change-password.vue', () => {
   beforeEach(() => {
-    testData.initialize();
+    mockHttp.initialize();
   });
 
   afterEach(() => {
-    testData.restore();
+    mockHttp.restore();
   });
 
   it('should render correct contents', () => {
@@ -35,7 +35,7 @@ describe('change-password.vue', () => {
   describe('change password', () => {
     let vm;
     beforeEach(() => {
-      testData.setPostResponse('/api/users/73/password', { status: 200 });
+      mockHttp.setPostResponse('/api/users/73/password', { status: 200 });
       store.commit('identity/login', {
         token: 'asdfiig93',
         user: {
@@ -67,7 +67,7 @@ describe('change-password.vue', () => {
 
     describe('on success', () => {
       it('should navigate to the profile page', async () => {
-        testData.setPostResponse('/api/users/73/password', {
+        mockHttp.setPostResponse('/api/users/73/password', {
           status: 200,
           body: { success: true }
         });
@@ -79,7 +79,7 @@ describe('change-password.vue', () => {
 
     describe('on failure', () => {
       beforeEach(() => {
-        testData.setPostResponse('/api/users/73/password', {
+        mockHttp.setPostResponse('/api/users/73/password', {
           status: 400,
           body: { reason: 'Error: Invalid Password' }
         });


### PR DESCRIPTION
The HTTP mock is just that. It only mocks the HTTP calls. All data setup, etc. is moved into the tests that need to data, making everything far less dependent on some global setup.

This also means that each test needs to potentially do more set up, but that is a good trade-off over trying to not break tests with global data changes.